### PR TITLE
Release/0.0.3 to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.0.3] - 2020-08-10
+### Updated
+- Updates the requirements on [django](https://github.com/django/django) to permit the latest version `<3.2.0`.
+- Updates the requirements on [djangorestframework](https://github.com/encode/django-rest-framework) to permit the latest version `3.11.2`.
+- Updates the requirements on `twilio` from ~=6.38.0 to ~=6.44.2
+- Updates the requirements on [drf-rw-serializers](https://github.com/vintasoftware/drf-rw-serializers) from `1.0.2` to `1.0.3`.
+
 ## [0.0.2] - 2020-04-09
 ### Added
 - Capability to create Twilio room via REST

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="django-twilio-access-token",
-    version="0.0.2",
+    version="0.0.3",
     author="Panji Y. Wiwaha",
     author_email="panjiyudasetya@gmail.com",
     description="A Django app to generate Twilio access token for particular Twilio services.",


### PR DESCRIPTION
## [0.0.3] - 2020-08-10
### Updated
- Updates the requirements on [django](https://github.com/django/django) to permit the latest version `<3.2.0`.
- Updates the requirements on [djangorestframework](https://github.com/encode/django-rest-framework) to permit the latest version `3.11.2`.
- Updates the requirements on `twilio` from ~=6.38.0 to ~=6.44.2
- Updates the requirements on [drf-rw-serializers](https://github.com/vintasoftware/drf-rw-serializers) from `1.0.2` to `1.0.3`.